### PR TITLE
Add group filter clear button and daily total sum display

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -742,6 +742,25 @@ function buildGroupDropdown() {
         return;
     }
 
+    const clearBtn = document.createElement('button');
+    clearBtn.type = 'button';
+    clearBtn.className = 'filter-dropdown-clear';
+    clearBtn.textContent = 'Clear all';
+    clearBtn.style.display = selectedGroups.size > 0 ? '' : 'none';
+    clearBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        selectedGroups.clear();
+        const available = new Set(getFilteredLicenses());
+        for (const lic of [...selectedLicenses]) {
+            if (!available.has(lic)) selectedLicenses.delete(lic);
+        }
+        updateFilterCount('group-count', 0);
+        buildGroupDropdown();
+        buildLicensesDropdown();
+        rerenderCharts();
+    });
+    panel.appendChild(clearBtn);
+
     availableGroups.forEach(group => {
         const item = document.createElement('label');
         item.className = 'filter-dropdown-item';
@@ -1307,6 +1326,17 @@ function renderTotalAmountChart(summaries) {
     const ctx = canvas.getContext('2d');
 
     if (charts.totalAmount) charts.totalAmount.destroy();
+
+    const totalSumEl = document.getElementById('total-amount-sum');
+    if (totalSumEl) {
+        if (!summaries || summaries.length === 0) {
+            totalSumEl.textContent = '';
+        } else {
+            const grandTotal = summaries.reduce((sum, s) => sum + s.totalAmount, 0);
+            totalSumEl.textContent = grandTotal.toFixed(3);
+        }
+    }
+
     if (!summaries || summaries.length === 0) return;
 
     const dates = [...new Set(summaries.map(s => s.date))].sort();

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -93,7 +93,7 @@
 
             <div class="card" data-expandable="true">
                 <div class="card-header">
-                    <div class="card-title"><h3>Daily Total</h3></div>
+                    <div class="card-title"><h3>Daily Total</h3><span id="total-amount-sum" class="card-title-stat"></span></div>
                     <button type="button" class="card-expand-btn" aria-label="Expand card">⤢</button>
                 </div>
                 <canvas id="totalAmountChart"></canvas>

--- a/dashboard/public/style.css
+++ b/dashboard/public/style.css
@@ -260,6 +260,15 @@ header.header {
     margin: 0;
 }
 
+.card-title-stat {
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    margin-left: 8px;
+    opacity: 0.8;
+}
+
 .card-expand-btn {
     background: transparent;
     border: none;
@@ -796,6 +805,11 @@ body.light {
     --red:            #880022;
 }
 
+body.light .card-title-stat {
+    color: var(--text-primary);
+    opacity: 1;
+}
+
 body.light .status-bar {
     background: #ebe6d8;
 }
@@ -963,6 +977,25 @@ body.light .status-badge.missing {
 
 body.light .filter-dropdown-item:hover {
     background: #ede8da;
+}
+
+.filter-dropdown-clear {
+    display: block;
+    width: 100%;
+    padding: 5px 10px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border);
+    color: var(--amber);
+    font: inherit;
+    font-size: 11px;
+    text-align: left;
+    cursor: pointer;
+    letter-spacing: 0.05em;
+}
+
+.filter-dropdown-clear:hover {
+    background: var(--border);
 }
 
 /* ── MISC ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Add "Clear all" button to group filter dropdown that clears selected groups and cascades deselection to licenses
- Show grand total sum in the Daily Total card header, updated dynamically on filter changes
- Add styles for the clear button and card title stat in both dark and light themes

## Test plan
- [ ] Open group filter dropdown — verify "Clear all" button appears only when groups are selected
- [ ] Click "Clear all" — verify groups and dependent licenses are deselected and charts re-render
- [ ] Check Daily Total card header shows grand total sum matching the chart data
- [ ] Switch to light theme and verify styling looks correct for both new elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)