### PR TITLE
Add cumulative/grouped toggle for daily total and average charts

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -30,6 +30,8 @@ let licenseSearchQuery = '';
 let licenseAnalyticsMap = new Map(); // Map<licenseId, Map<date, uptime 0–1>>
 let availableGroups = [];
 let selectedGroups = new Set();
+let totalChartCumulative = false;
+let averageChartCumulative = false;
 let selectedLicenses = new Set();
 let selectedTasks = new Set();
 let web3Account = '';
@@ -170,6 +172,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initFilterDropdowns();
     initializeCardExpansion();
     initializeTableSorting();
+    initializeCumulativeToggles();
     updateWeb3Ui();
     if (!DEBUG_INFO) {
         const debugElement = document.getElementById('token-debug');
@@ -773,6 +776,7 @@ function buildGroupDropdown() {
 
     if (!hasGroups) {
         updateFilterCount('group-count', 0);
+        updateCumulativeToggleVisibility();
         return;
     }
 
@@ -789,6 +793,7 @@ function buildGroupDropdown() {
             if (!available.has(lic)) selectedLicenses.delete(lic);
         }
         updateFilterCount('group-count', 0);
+        updateCumulativeToggleVisibility();
         buildGroupDropdown();
         buildLicensesDropdown();
         buildTaskDropdown();
@@ -814,6 +819,7 @@ function buildGroupDropdown() {
             }
 
             updateFilterCount('group-count', selectedGroups.size);
+            updateCumulativeToggleVisibility();
             refreshGroupDisabledState();
             buildLicensesDropdown();
             buildTaskDropdown();
@@ -825,6 +831,7 @@ function buildGroupDropdown() {
     });
 
     updateFilterCount('group-count', selectedGroups.size);
+    updateCumulativeToggleVisibility();
     refreshGroupDisabledState();
 }
 
@@ -1049,6 +1056,8 @@ function logout() {
         selectedGroups.clear();
         selectedLicenses.clear();
         selectedTasks.clear();
+        totalChartCumulative = false;
+        averageChartCumulative = false;
         web3Signature = '';
         web3Account = '';
         stopAutoRefresh();
@@ -1091,6 +1100,44 @@ function initializeCardExpansion() {
             closeCardOverlay();
         }
     });
+}
+
+function initializeCumulativeToggles() {
+    const totalToggle = document.getElementById('total-cumulative-toggle');
+    const averageToggle = document.getElementById('average-cumulative-toggle');
+
+    if (totalToggle) {
+        totalToggle.addEventListener('change', () => {
+            totalChartCumulative = totalToggle.checked;
+            rerenderCharts();
+        });
+    }
+
+    if (averageToggle) {
+        averageToggle.addEventListener('change', () => {
+            averageChartCumulative = averageToggle.checked;
+            rerenderCharts();
+        });
+    }
+}
+
+function updateCumulativeToggleVisibility() {
+    const showToggle = selectedGroups.size > 1;
+
+    const totalWrap = document.getElementById('total-cumulative-toggle-wrap');
+    if (totalWrap) totalWrap.style.display = showToggle ? '' : 'none';
+
+    const averageWrap = document.getElementById('average-cumulative-toggle-wrap');
+    if (averageWrap) averageWrap.style.display = showToggle ? '' : 'none';
+
+    if (!showToggle) {
+        totalChartCumulative = false;
+        averageChartCumulative = false;
+        const totalToggle = document.getElementById('total-cumulative-toggle');
+        if (totalToggle) totalToggle.checked = false;
+        const averageToggle = document.getElementById('average-cumulative-toggle');
+        if (averageToggle) averageToggle.checked = false;
+    }
 }
 
 function initializeTableSorting() {
@@ -1426,12 +1473,13 @@ function renderTotalAmountChart(summaries) {
 
     const totalSumEl = document.getElementById('total-amount-sum');
     const activeGroups = [...selectedGroups];
+    const splitByGroup = activeGroups.length > 0 && !(activeGroups.length > 1 && totalChartCumulative);
 
     if (totalSumEl) {
         totalSumEl.innerHTML = '';
         if (!summaries || summaries.length === 0) {
             // leave empty
-        } else if (activeGroups.length > 0) {
+        } else if (splitByGroup) {
             activeGroups.forEach((group, i) => {
                 const groupTotal = summaries
                     .filter(s => licenseGroupMap.get(s.licenseId)?.has(group))
@@ -1453,7 +1501,7 @@ function renderTotalAmountChart(summaries) {
     const dates = [...new Set(summaries.map(s => s.date))].sort();
     let datasets;
 
-    if (activeGroups.length > 0) {
+    if (splitByGroup) {
         datasets = activeGroups.map((group, i) => {
             const color = getSeriesColor(i);
             const byDate = new Map();
@@ -1528,6 +1576,9 @@ function renderAverageChart(summaries) {
 
     const dates = [...new Set(summaries.map(s => s.date))].sort();
     const activeLicenses = [...selectedLicenses];
+    const activeGroups = [...selectedGroups];
+    const splitByGroup = activeLicenses.length === 0 && activeGroups.length > 0
+        && !(activeGroups.length > 1 && averageChartCumulative);
     let rewardDatasets;
 
     if (activeLicenses.length > 0) {
@@ -1541,6 +1592,38 @@ function renderAverageChart(summaries) {
                 type: 'line',
                 label: lic,
                 data: dates.map(d => byDate.has(d) ? byDate.get(d) : null),
+                borderColor: color,
+                backgroundColor: color + '14',
+                tension: 0.1,
+                fill: false,
+                pointRadius: 2,
+                pointHoverRadius: 4,
+                spanGaps: true,
+                yAxisID: 'y'
+            };
+        });
+    } else if (splitByGroup) {
+        rewardDatasets = activeGroups.map((group, i) => {
+            const color = getSeriesColor(i);
+            const dayAgg = new Map();
+            summaries
+                .filter(s => licenseGroupMap.get(s.licenseId)?.has(group))
+                .forEach(s => {
+                    if (!dayAgg.has(s.date)) dayAgg.set(s.date, { total: 0, count: 0, licenses: 0 });
+                    const d = dayAgg.get(s.date);
+                    d.total += s.totalAmount;
+                    d.count += s.count;
+                    d.licenses += 1;
+                });
+            const meta = dates.map(d => dayAgg.get(d) || null);
+            return {
+                type: 'line',
+                label: group,
+                _meta: meta,
+                data: dates.map(d => {
+                    const agg = dayAgg.get(d);
+                    return agg && agg.licenses > 0 ? agg.total / agg.licenses : null;
+                }),
                 borderColor: color,
                 backgroundColor: color + '14',
                 tension: 0.1,

--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -776,7 +776,7 @@ function buildGroupDropdown() {
 
     if (!hasGroups) {
         updateFilterCount('group-count', 0);
-        updateCumulativeToggleVisibility();
+        syncCumulativeToggles();
         return;
     }
 
@@ -793,7 +793,6 @@ function buildGroupDropdown() {
             if (!available.has(lic)) selectedLicenses.delete(lic);
         }
         updateFilterCount('group-count', 0);
-        updateCumulativeToggleVisibility();
         buildGroupDropdown();
         buildLicensesDropdown();
         buildTaskDropdown();
@@ -819,7 +818,7 @@ function buildGroupDropdown() {
             }
 
             updateFilterCount('group-count', selectedGroups.size);
-            updateCumulativeToggleVisibility();
+            syncCumulativeToggles();
             refreshGroupDisabledState();
             buildLicensesDropdown();
             buildTaskDropdown();
@@ -831,7 +830,7 @@ function buildGroupDropdown() {
     });
 
     updateFilterCount('group-count', selectedGroups.size);
-    updateCumulativeToggleVisibility();
+    syncCumulativeToggles();
     refreshGroupDisabledState();
 }
 
@@ -1121,7 +1120,7 @@ function initializeCumulativeToggles() {
     }
 }
 
-function updateCumulativeToggleVisibility() {
+function syncCumulativeToggles() {
     const showToggle = selectedGroups.size > 1;
 
     const totalWrap = document.getElementById('total-cumulative-toggle-wrap');
@@ -1133,10 +1132,8 @@ function updateCumulativeToggleVisibility() {
     if (!showToggle) {
         totalChartCumulative = false;
         averageChartCumulative = false;
-        const totalToggle = document.getElementById('total-cumulative-toggle');
-        if (totalToggle) totalToggle.checked = false;
-        const averageToggle = document.getElementById('average-cumulative-toggle');
-        if (averageToggle) averageToggle.checked = false;
+        if (totalWrap) totalWrap.querySelector('input').checked = false;
+        if (averageWrap) averageWrap.querySelector('input').checked = false;
     }
 }
 
@@ -1566,6 +1563,18 @@ function renderTotalAmountChart(summaries) {
     });
 }
 
+function buildDayAggAvg(entries) {
+    const dayAgg = new Map();
+    entries.forEach(s => {
+        if (!dayAgg.has(s.date)) dayAgg.set(s.date, { total: 0, count: 0, licenses: 0 });
+        const d = dayAgg.get(s.date);
+        d.total += s.averageAmount;
+        d.count += s.count;
+        d.licenses += 1;
+    });
+    return dayAgg;
+}
+
 function renderAverageChart(summaries) {
     const canvas = document.getElementById('averageChart');
     if (!canvas) return;
@@ -1605,16 +1614,7 @@ function renderAverageChart(summaries) {
     } else if (splitByGroup) {
         rewardDatasets = activeGroups.map((group, i) => {
             const color = getSeriesColor(i);
-            const dayAgg = new Map();
-            summaries
-                .filter(s => licenseGroupMap.get(s.licenseId)?.has(group))
-                .forEach(s => {
-                    if (!dayAgg.has(s.date)) dayAgg.set(s.date, { total: 0, count: 0, licenses: 0 });
-                    const d = dayAgg.get(s.date);
-                    d.total += s.totalAmount;
-                    d.count += s.count;
-                    d.licenses += 1;
-                });
+            const dayAgg = buildDayAggAvg(summaries.filter(s => licenseGroupMap.get(s.licenseId)?.has(group)));
             const meta = dates.map(d => dayAgg.get(d) || null);
             return {
                 type: 'line',
@@ -1635,14 +1635,7 @@ function renderAverageChart(summaries) {
             };
         });
     } else {
-        const dayAgg = new Map();
-        summaries.forEach(s => {
-            if (!dayAgg.has(s.date)) dayAgg.set(s.date, { total: 0, count: 0, licenses: 0 });
-            const d = dayAgg.get(s.date);
-            d.total += s.totalAmount;
-            d.count += s.count;
-            d.licenses += 1;
-        });
+        const dayAgg = buildDayAggAvg(summaries);
         const c0 = getSeriesColor(0);
         const rewardsMeta = dates.map(d => dayAgg.get(d) || null);
         rewardDatasets = [{

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -103,6 +103,9 @@
             <div class="card" data-expandable="true">
                 <div class="card-header">
                     <div class="card-title"><h3>Daily Total</h3><span id="total-amount-sum" class="card-title-stat"></span></div>
+                    <label class="card-toggle" id="total-cumulative-toggle-wrap" style="display:none">
+                        <input type="checkbox" id="total-cumulative-toggle"> Cumulative
+                    </label>
                     <button type="button" class="card-expand-btn" aria-label="Expand card">⤢</button>
                 </div>
                 <canvas id="totalAmountChart"></canvas>
@@ -111,6 +114,9 @@
             <div class="card" data-expandable="true">
                 <div class="card-header">
                     <div class="card-title"><h3>Daily Average</h3></div>
+                    <label class="card-toggle" id="average-cumulative-toggle-wrap" style="display:none">
+                        <input type="checkbox" id="average-cumulative-toggle"> Cumulative
+                    </label>
                     <button type="button" class="card-expand-btn" aria-label="Expand card">⤢</button>
                 </div>
                 <canvas id="averageChart"></canvas>

--- a/dashboard/public/style.css
+++ b/dashboard/public/style.css
@@ -269,6 +269,22 @@ header.header {
     opacity: 0.8;
 }
 
+.card-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--text-dim);
+    white-space: nowrap;
+    flex-shrink: 0;
+    cursor: pointer;
+    user-select: none;
+}
+
+.card-toggle input[type="checkbox"] {
+    cursor: pointer;
+}
+
 .card-expand-btn {
     background: transparent;
     border: none;


### PR DESCRIPTION
## Summary

- Adds a **Cumulative** toggle to the Daily Total and Daily Average chart cards, visible when 2+ groups are selected
- When enabled, collapses per-group series into a single aggregate line
- Toggles reset automatically when the group selection drops to ≤1

## Fixes (from code review)

- **Metric inconsistency**: Daily Average group-split view was plotting `totalAmount / licenseCount` while the license-split view used `averageAmount`; all three paths now use `averageAmount` via a shared `buildDayAggAvg` helper
- **Duplication**: extracted `buildDayAggAvg` to replace two near-identical aggregation blocks
- **Naming**: renamed `updateCumulativeToggleVisibility` → `syncCumulativeToggles` to reflect that it also resets JS state and checkbox DOM
- **Redundant DOM queries**: `syncCumulativeToggles` now uses `querySelector` on already-retrieved wrapper refs instead of re-querying by ID
- **Double call**: removed redundant `syncCumulativeToggles` call from the clear-all handler

## Test plan

- [ ] Select 1 group — Cumulative toggle is hidden, chart shows single group series
- [ ] Select 2+ groups — Cumulative toggle appears on both Daily Total and Daily Average cards
- [ ] Enable Cumulative on Daily Total — per-group lines collapse to one aggregate line; sum stat shows grand total
- [ ] Enable Cumulative on Daily Average — per-group lines collapse to one aggregate line
- [ ] Deselect groups back to 1 — toggle disappears and charts revert to split view
- [ ] Clear all groups — toggles hidden, cumulative state reset
- [ ] Filter by a specific license — Daily Average shows `averageAmount` per license (unchanged)
- [ ] Remove license filter with groups selected — Daily Average group-split uses same `averageAmount` metric