### PR TITLE
Rebrand to U-Network and remove Terms of Service

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -41,7 +41,7 @@ let refreshIntervalId = null;
 let currentDateFilter = 'current_month';
 let rawAllocations = null;
 
-const NO_TASK_LABEL = '(none)';
+const NO_TASK_LABEL = 'PoW';
 
 const tableComparators = {
     date: (a, b) => a.date.localeCompare(b.date),

--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -15,7 +15,6 @@ const TOKEN_URL = UNITY_CONFIG.TOKEN_URL || "https://api.unityedge.io/auth/v1/to
 const CHAIN_ID = UNITY_CONFIG.CHAIN_ID || "";
 const DOMAIN = UNITY_CONFIG.DOMAIN || "unitynodes.io";
 const URI = UNITY_CONFIG.URI || "https://unitynodes.io";
-const TERMS_URL = UNITY_CONFIG.TERMS_URL || "https://unitynodes.io/terms-and-conditions.html";
 const DEBUG_INFO = UNITY_CONFIG.DEBUG_INFO !== undefined ? UNITY_CONFIG.DEBUG_INFO : true;
 
 // State
@@ -623,7 +622,7 @@ function updateWeb3Ui(message) {
 
 function buildWeb3Message(walletAddress) {
     const issuedAt = new Date().toISOString();
-    return `${DOMAIN} wants you to sign in with your Ethereum account:\n${walletAddress}\n\nI accept the UnityNodes Terms of Service: ${TERMS_URL}\nURI: ${URI}\nVersion: 1\nChain ID: ${CHAIN_ID}\nIssued At: ${issuedAt}`;
+    return `${DOMAIN} wants you to sign in with your Ethereum account:\n${walletAddress}\n\nURI: ${URI}\nVersion: 1\nChain ID: ${CHAIN_ID}\nIssued At: ${issuedAt}`;
 }
 
 async function connectWallet() {

--- a/dashboard/public/config.js
+++ b/dashboard/public/config.js
@@ -9,6 +9,5 @@ window.UNITY_CONFIG = {
   CHAIN_ID: "869",
   DOMAIN: "unitynodes.io",
   URI: "https://unitynodes.io",
-  TERMS_URL: "https://unitynodes.io/terms-and-conditions.html",
   DEBUG_INFO: false
 };

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Unity Rewards Dashboard</title>
+    <title>U-Network Rewards Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
@@ -13,8 +13,7 @@
 <body>
 
     <header class="header">
-        <img class="unity-logo" src="https://unitynodes.io/images/Unity-Icon_1.png" alt="Unity" />
-        <span class="header-title">Unity Rewards</span>
+        <span class="header-title">U-Network Rewards</span>
         <div class="date-filter-group">
             <button type="button" class="date-filter-btn" data-filter="current_week">CW</button>
             <button type="button" class="date-filter-btn" data-filter="last_week">LW</button>
@@ -170,7 +169,7 @@
     <section id="auth-section" class="auth-overlay">
         <div class="auth-terminal">
             <div class="auth-terminal-header">
-                <span>Unity Rewards Dashboard — Authentication Required</span>
+                <span>U-Network Rewards Dashboard — Authentication Required</span>
                 <button class="theme-toggle-btn" type="button" title="Toggle light/dark theme">◑</button>
             </div>
             <div class="auth-terminal-body">

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -186,9 +186,6 @@
                     </div>
                 </div>
             </div>
-            <div class="auth-footer">
-                <p>By logging in you agree to our <a href="https://unitynodes.io/terms-and-conditions.html" class="footer-link">Terms of Service</a></p>
-            </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary

- Replaces all Unity/UnityNodes branding with U-Network Rewards across title, header, and auth screen
- Labels uncategorized tasks as **PoW** instead of `(none)`
- Removes all Terms of Service references (auth footer, MetaMask sign-in message, `TERMS_URL` constant and config entry)

## Changes

- `index.html` — updated title, header title, auth screen header; removed auth footer with ToS link
- `app.js` — updated MetaMask sign-in message brand name; removed `TERMS_URL` constant and ToS line from sign-in payload
- `config.js` — removed `TERMS_URL` entry
- `app.js` — `NO_TASK_LABEL` changed from `'(none)'` to `'PoW'`

## Test plan

- [ ] Page title reads "U-Network Rewards Dashboard"
- [ ] Header shows "U-NETWORK REWARDS" with no logo
- [ ] Auth screen header reads "U-Network Rewards Dashboard — Authentication Required"
- [ ] Auth screen has no Terms of Service text or link
- [ ] MetaMask sign-in prompt contains no ToS reference
- [ ] Tasks with no category show "PoW" in the task column